### PR TITLE
Adds query index for hr-glossary

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -116,3 +116,21 @@ indices:
         select: head > meta[name="publication-date"]
         value: |
           attribute(el, 'content')
+
+    hr-glossary:
+      include:
+        - '/hr-glossary/**'
+      target: /hr-glossary/query-index
+      properties:
+        title:
+          select: head > meta[property="og:title"]
+          value: |
+            attribute(el, 'content')
+        robots:
+          select: head > meta[name="robots"]
+          value: |
+            attribute(el, 'content')
+        lastModified:
+          select: none
+          value: |
+            parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -10,3 +10,8 @@ sitemaps:
     origin: https://www.bamboohr.com
     source: /integrations/query-index.json
     destination: /integrations/sitemap.xml
+
+  hrGlossary:
+      origin: https://www.bamboohr.com
+      source: /hr-glossary/query-index.json
+      destination: /hr-glossary/sitemap.xml


### PR DESCRIPTION
Adds query-index file for hr-glossary. Adds hr glossary to yaml files.

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/hr-glossary/
- After: https://groberts-query-hr-glossary--bamboohr-website--bamboohr.hlx.page/hr-glossary/
