### PR TITLE
Groberts/terms glossary block

### DIFF
--- a/blog/blocks/app-cards/app-cards.js
+++ b/blog/blocks/app-cards/app-cards.js
@@ -60,6 +60,7 @@ export function sortOptions(sortBy) {
                                 || a.time.localeCompare(b.time)
                                 || a.category.localeCompare(b.category),
     title: (a, b) => a.title.localeCompare(b.title),
+    term: (a, b) => a.term.localeCompare(b.term),
   };
   return sorts[sortBy];
 }

--- a/blog/blocks/terms-glossary/terms-glossary.css
+++ b/blog/blocks/terms-glossary/terms-glossary.css
@@ -1,3 +1,7 @@
+main .section > div.terms-glossary-wrapper {
+    max-width: 1200px;
+}
+
 .glossary-group-container {
     margin-bottom: 60px;
 }

--- a/blog/blocks/terms-glossary/terms-glossary.css
+++ b/blog/blocks/terms-glossary/terms-glossary.css
@@ -1,0 +1,31 @@
+.glossary-group-container {
+    margin-bottom: 60px;
+}
+
+.glossary-group-letter {
+    color: var(--color-gray-12);
+    margin-bottom: 20px;
+}
+
+main a.glossary-link {
+    display: block;
+    line-height: 28px;
+}
+
+@media screen and (min-width: 600px) {
+    .glossary-term-container {
+        column-count: 2;
+        column-gap: 60px;
+    }
+    .glossary-group-container {
+        -webkit-column-break-inside: avoid;
+        page-break-inside: avoid;
+        break-inside: avoid;
+    }
+}
+@media screen and (min-width: 1024px) {
+    .glossary-term-container {
+        column-count: 3;
+        column-gap: 10px;
+    }
+}

--- a/blog/blocks/terms-glossary/terms-glossary.js
+++ b/blog/blocks/terms-glossary/terms-glossary.js
@@ -5,24 +5,18 @@ import {
 
 import { sortOptions } from '../app-cards/app-cards.js';
   
-  
   export async function filterTerms(config, block) {
   
     await lookupPages([], 'hrGlossary');
     const index = window.pageIndex.hrGlossary;
-
-    // sort alphabetically by term
     const sortBy = 'term';
     if (sortBy && sortOptions(sortBy)) index.data.sort(sortOptions(sortBy));
-    
     const glossaryTermContainer = document.createElement('div');
     glossaryTermContainer.className = 'glossary-term-container';
     block.append(glossaryTermContainer);
 
     index.data.forEach((glossaryItem) => {
       if (glossaryItem.term != '') {
-
-        //grab the first letter of each term
         const term = glossaryItem.term;
         const glossaryLetter = term.charAt(0);
         if (glossaryLetter >= '0' && glossaryLetter <= '9') {
@@ -30,27 +24,20 @@ import { sortOptions } from '../app-cards/app-cards.js';
         } else {
           glossaryItem.groupLetter = glossaryLetter;
         }
-        
       }
     });
 
-    // Accepts the array and key
     const groupBy = (array, key) => {
-      // Return the end result
       return array.reduce((result, currentValue) => {
-        // If an array already present for key, push it to the array. Else create an array and push the object
         (result[currentValue[key]] = result[currentValue[key]] || []).push(
           currentValue
         );
-        // Return the current iteration `result` value, this will be taken as next iteration `result` value and accumulate
         return result;
-      }, {}); // empty object is the initial value for result object
+      }, {});
     };
 
-    // Group by first letter as key to the person array
     const glossaryGroupedByLetter = groupBy(index.data, 'groupLetter');
     
-    //Converts objects to arrays
     const glossaryGroups = Object.entries(glossaryGroupedByLetter);
 
     glossaryGroups.forEach((glossaryGroup) => {
@@ -74,8 +61,6 @@ import { sortOptions } from '../app-cards/app-cards.js';
       }
     });
   }
-
-
   
   export default async function decorate(block) {
     const config = readBlockConfig(block);

--- a/blog/blocks/terms-glossary/terms-glossary.js
+++ b/blog/blocks/terms-glossary/terms-glossary.js
@@ -18,9 +18,6 @@ import { sortOptions } from '../app-cards/app-cards.js';
     const glossaryTermContainer = document.createElement('div');
     glossaryTermContainer.className = 'glossary-term-container';
     block.append(glossaryTermContainer);
-    // const glossaryGroupContainer = document.createElement('div');
-    // glossaryGroupContainer.className = 'glossary-group-container';
-    // glossaryTermContainer.append(glossaryGroupContainer);
 
     index.data.forEach((glossaryItem) => {
       if (glossaryItem.term != '') {
@@ -66,7 +63,6 @@ import { sortOptions } from '../app-cards/app-cards.js';
         glossaryGroupContainer.append(glossaryGroupLetter);
         glossaryGroupLetter.textContent = glossaryGroup[0];
         glossaryGroupLetter.id = glossaryGroup[0];
-        console.log(glossaryGroup[0]);
 
         glossaryGroup[1].forEach((glossaryGroupItem) => {
           const glossaryLink = document.createElement('a');

--- a/blog/blocks/terms-glossary/terms-glossary.js
+++ b/blog/blocks/terms-glossary/terms-glossary.js
@@ -1,0 +1,89 @@
+import {
+    lookupPages,
+    readBlockConfig,
+  } from '../../scripts/scripts.js';
+
+import { sortOptions } from '../app-cards/app-cards.js';
+  
+  
+  export async function filterTerms(config, block) {
+  
+    await lookupPages([], 'hrGlossary');
+    const index = window.pageIndex.hrGlossary;
+
+    // sort alphabetically by term
+    const sortBy = 'term';
+    if (sortBy && sortOptions(sortBy)) index.data.sort(sortOptions(sortBy));
+    
+    const glossaryTermContainer = document.createElement('div');
+    glossaryTermContainer.className = 'glossary-term-container';
+    block.append(glossaryTermContainer);
+    // const glossaryGroupContainer = document.createElement('div');
+    // glossaryGroupContainer.className = 'glossary-group-container';
+    // glossaryTermContainer.append(glossaryGroupContainer);
+
+    index.data.forEach((glossaryItem) => {
+      if (glossaryItem.term != '') {
+
+        //grab the first letter of each term
+        const term = glossaryItem.term;
+        const glossaryLetter = term.charAt(0);
+        if (glossaryLetter >= '0' && glossaryLetter <= '9') {
+          glossaryItem.groupLetter = '#';
+        } else {
+          glossaryItem.groupLetter = glossaryLetter;
+        }
+        
+      }
+    });
+
+    // Accepts the array and key
+    const groupBy = (array, key) => {
+      // Return the end result
+      return array.reduce((result, currentValue) => {
+        // If an array already present for key, push it to the array. Else create an array and push the object
+        (result[currentValue[key]] = result[currentValue[key]] || []).push(
+          currentValue
+        );
+        // Return the current iteration `result` value, this will be taken as next iteration `result` value and accumulate
+        return result;
+      }, {}); // empty object is the initial value for result object
+    };
+
+    // Group by first letter as key to the person array
+    const glossaryGroupedByLetter = groupBy(index.data, 'groupLetter');
+    
+    //Converts objects to arrays
+    const glossaryGroups = Object.entries(glossaryGroupedByLetter);
+
+    glossaryGroups.forEach((glossaryGroup) => {
+      if (glossaryGroup[0] != 'undefined') {
+        const glossaryGroupContainer = document.createElement('div');
+        glossaryGroupContainer.className = 'glossary-group-container';
+        glossaryTermContainer.append(glossaryGroupContainer);
+        const glossaryGroupLetter = document.createElement('div');
+        glossaryGroupLetter.className = 'glossary-group-letter typ-title1';
+        glossaryGroupContainer.append(glossaryGroupLetter);
+        glossaryGroupLetter.textContent = glossaryGroup[0];
+        glossaryGroupLetter.id = glossaryGroup[0];
+        console.log(glossaryGroup[0]);
+
+        glossaryGroup[1].forEach((glossaryGroupItem) => {
+          const glossaryLink = document.createElement('a');
+          glossaryLink.textContent = glossaryGroupItem.term;
+          glossaryLink.href = glossaryGroupItem.path;
+          glossaryLink.className = 'glossary-link';
+          glossaryGroupContainer.append(glossaryLink);
+        });
+      }
+    });
+  }
+
+
+  
+  export default async function decorate(block) {
+    const config = readBlockConfig(block);
+    filterTerms(config, block);
+    block.innerHTML = '';
+  }
+  

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -895,6 +895,7 @@ export async function lookupPages(pathnames, collection) {
   const indexPaths = {
     blog: '/blog/fixtures/blog-query-index.json',
     integrations: '/integrations/query-index.json?sheet=listings',
+    hrGlossary: '/hr-glossary/query-index.json',
     hrvs: '/drafts/sclayton/resources/hr-vs/query-index.json',
   };
   const indexPath = indexPaths[collection];


### PR DESCRIPTION
Builds out a terms-glossary block. Block will go through helix-query file and display the items by term with a link to the path.

Fix #ZZ-1300

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/hr-glossary/
- After: https://groberts-terms-glossary-block--bamboohr-website--bamboohr.hlx.page/hr-glossary/
