### PR TITLE
mt theme

### DIFF
--- a/styles/style-vars.css
+++ b/styles/style-vars.css
@@ -897,30 +897,37 @@ div.secondary-teal {
   color: var(--color-white);
 }
 
-.theme {
+.theme,
+.color-base :is(h1, h2, h3, h4, h5, h6) {
   color: var(--theme-base);
 }
 
-.theme-tint-5 {
+.theme-tint-5,
+.color-tint-5 :is(h1, h2, h3, h4, h5, h6) {
   color: var(--theme-tint5);
 }
 
-.theme-tint-15 {
-  color: var(--theme-tint15);
-}
-
-.theme-tint-10 {
+.theme-tint-10,
+.color-tint-10 :is(h1, h2, h3, h4, h5, h6) {
   color: var(--theme-tint10);
 }
 
-.theme-shade-5 {
+.theme-tint-15,
+.color-tint-15 :is(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-tint15);
+}
+
+.theme-shade-5,
+.color-shade-5 :is(h1, h2, h3, h4, h5, h6) {
   color: var(--theme-shade5);
 }
 
-.theme-shade-10 {
+.theme-shade-10,
+.color-shade-10 :is(h1, h2, h3, h4, h5, h6) {
   color: var(--theme-shade10);
 }
 
-.theme-shade-15 {
+.theme-shade-15,
+.color-shade-15 :is(h1, h2, h3, h4, h5, h6) {
   color: var(--theme-shade15);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -290,10 +290,18 @@ main h6 {
   color: var(--heading-color);
   font-weight: var(--heading-font-weight);
   font-family: var(--heading-font-family);
-  font-style: italic;
   margin-top: 48px;
   margin-bottom: 16px;
   scroll-margin: 80px;
+}
+
+.blog-post main h1,
+.blog-post main h2,
+.blog-post main h3,
+.blog-post main h4,
+.blog-post main h5,
+.blog-post main h6 {
+  font-style: italic;
 }
 
 main h1 {
@@ -819,9 +827,12 @@ main .section.max-width-small > div {
 }
 
 main .section p.button-container {
-  text-align: center;
   margin-top: 16px;
   margin-bottom: 0;
+}
+
+main .section .default-content-wrapper .button-container {
+  text-align: center;
 }
 
 .integrations .home-featured-cat p.button-container {

--- a/styles/themes/base.css
+++ b/styles/themes/base.css
@@ -5,9 +5,7 @@
 }
 
 /** base tags **/
-#base :is(h1, h2, h3, h4, h5, h6) {
-  font-style: normal;
-  color: var(--color-gray-11);
+#base .title-spacing-top :is(h1, h2, h3, h4, h5, h6) {
   margin-top: 1.25em;
 }
 
@@ -15,6 +13,7 @@
   width: 100%;
 }
 
+#base [data-align='center'],
 #base [data-align='center'] :is(h1, h2, h3, h4, h5, h6, p) {
   text-align: center;
 }
@@ -23,8 +22,14 @@
   width: 100%;
 }
 
+#base [data-align='right'],
 #base [data-align='right'] :is(h1, h2, h3, h4, h5, h6, p) {
   text-align: right;
+}
+
+#base [data-align='left'],
+#base [data-align='left'] :is(h1, h2, h3, h4, h5, h6, p) {
+  text-align: left;
 }
 
 /** section **/
@@ -235,7 +240,6 @@
 
 #base .button-container {
   margin: 0;
-  text-align: unset;
 }
 
 #base .button-style-link .button-container {


### PR DESCRIPTION
- remove default title style on base theme
- move button center to more specific class instead of making all the buttons default to center(which base theme override it to reset)
- 

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/about-bamboohr/hr-experience-maker-awards/
- https://main--bamboohr-website--bamboohr.hlx.page/resources/guides/2022-year-review
- https://main--bamboohr-website--bamboohr.hlx.page/resources/guides/better-performance-reviews-drive-employee-growth
- After: https://mtian-theme--bamboohr-website--bamboohr.hlx.page/about-bamboohr/hr-experience-maker-awards/
https://mtian-theme--bamboohr-website--bamboohr.hlx.page/resources/guides/2022-year-review
https://mtian-theme--bamboohr-website--bamboohr.hlx.page/resources/guides/better-performance-reviews-drive-employee-growth