### PR TITLE
ZZ-1332

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -552,7 +552,7 @@ header .nav-section.nav-section-subscribe form {
     cursor: default;
     display: flex;
     align-items: center;
-    height: 60px;
+    height: 67px;
     border: none;
     white-space: nowrap;
   }

--- a/styles/style-vars.css
+++ b/styles/style-vars.css
@@ -61,7 +61,7 @@
   --color-gray-4: #d5d4d2;
   --color-gray-5: #c8c8c6;
   --color-gray-6: #babab9;
-  --color-gray-7: #babab9;
+  --color-gray-7: #969797;
   --color-gray-8: #87888b;
   --color-gray-9: #74767a;
   --color-gray-10: #626467;


### PR DESCRIPTION
1) Fixed --color-gray-7
2) Aligning nav sections in the center caused the menu to drift down--noticeable on hover, the green top border was lower than we want. But worse than that a gap was created at the bottom. So moving the mouse slowly leaves the section and closes the menu. The fix is to adjust the height to match the entire area leaving no gaps at the top or bottom.

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/
- After: https://sclayton-zz1332-bugs--bamboohr-website--bamboohr.hlx.page/
