### PR TITLE
feat: auto-sprite svg icons to improve loading performances

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -233,6 +233,12 @@ main .carousel.style-1 span.icon {
   transition: color 0.25s ease-in-out;
 }
 
+main .carousel.style-1 span.icon svg {
+  max-width: 32px;
+  max-height: 32px;
+
+}
+
 main .carousel.style-1 h2 {
   color: var(--theme-shade5);
   font-family: var(--heading-font-family);

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -91,6 +91,8 @@ footer .footer .social p {
 
 footer .footer .social .icon {
 	padding: 4px;
+	height: 22px;
+	width: 22px;
 }
 
 footer .footer .brand {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -377,6 +377,11 @@ header .nav-buttons .nav-search-text-area.show-input {
   display: flex;
 }
 
+header .nav-buttons .icon {
+  height: 24px;
+  width: 24px;
+}
+
 .nav-search-input-wrapper {
   width: 100%;
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -10,9 +10,7 @@
   color: #9CA393;
 }
 
-
-.nav-brand .icon {
-  width: 150px;
+.nav-brand .icon svg {
   height: 23px;
 }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -11,6 +11,7 @@
 }
 
 .nav-brand .icon svg {
+  width: 150px;
   height: 23px;
 }
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -10,6 +10,12 @@
   color: #9CA393;
 }
 
+
+.nav-brand .icon {
+  width: 150px;
+  height: 23px;
+}
+
 .nav-search-btn .icon-search svg {
   color: var(--color-1);
 }

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -124,6 +124,11 @@
   align-items: center;
 }
 
+.table .icon-checkmark svg {
+  width: 18px;
+  height: 18px;
+}
+
 .table.comparison .elite-ribbon::after,
 .table.comparison .pro-ribbon::after {
   font-size: 17px;

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -122,11 +122,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-}
-
-.table .icon-checkmark svg {
-  width: 18px;
-  height: 18px;
+  height: 14px;
 }
 
 .table.comparison .elite-ribbon::after,

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,3 @@
 mountpoints:
   /: https://drive.google.com/drive/folders/0AIerlgs8oIQXUk9PVA
+

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -9,9 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import performanceLogger from './performance.js';
-
-performanceLogger();
 
 /**
  * log RUM if part of the sample.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -9,6 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import performanceLogger from './performance.js';
+
+performanceLogger();
 
 /**
  * log RUM if part of the sample.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -255,6 +255,8 @@ export async function decorateIcons(element) {
         const svg = await response.text();
         symbols[iconName] = svg
           .replace('<svg', `<symbol id="${iconName}"`)
+          .replace(/ width=".*?"/, '')
+          .replace(/ height=".*?"/, '')
           .replace('</svg>', '</symbol>');
       } catch (err) {
         console.error(err);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -274,7 +274,7 @@ export async function decorateIcons(element) {
     svgSprite.innerHTML += Object.values(symbols).join('\n');
   }
 
-  element.querySelectorAll('span.icon').forEach(async (span) => {
+  icons.forEach(async (span) => {
     const iconName = span.className.split('icon-')[1];
     const parent = span.firstElementChild?.tagName === 'A' ? span.firstElementChild : span;
     parent.innerHTML =

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -249,6 +249,7 @@ export async function decorateIcons(element) {
   await Promise.all(icons.map(async (span) => {
     const iconName = span.className.split('icon-')[1];
     if (!symbols[iconName]) {
+      symbols[iconName] = true;
       try {
         const response = await fetch(`${fetchBase}${window.hlx.codeBasePath}/icons/${iconName}.svg`);
         const svg = await response.text();

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -210,6 +210,16 @@ a.button > svg > use {
   color: currentcolor;
 }
 
+.icon {
+  display: inline-block;
+}
+
+.icon svg {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+}
+
 /* headings and body */
 
 main,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -210,6 +210,10 @@ a.button > svg > use {
   color: currentcolor;
 }
 
+.icon {
+  display: inline-block;
+}
+
 .icon svg {
   display: inline-block;
   width: 100%;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -210,10 +210,6 @@ a.button > svg > use {
   color: currentcolor;
 }
 
-.icon {
-  display: inline-block;
-}
-
 .icon svg {
   display: inline-block;
   width: 100%;


### PR DESCRIPTION
## The problem

During our work on the website it became apparent that on some of the pages that use a lot of icons, the loading of the post-LCP part is delayed quite a bit by the amount of network calls that are done.

For instance, on https://main--bamboohr-website--bamboohr.hlx.live/integrations/benefitadmincomparisonmatrix we have a loading sequence that looks like:
![Screenshot 2022-12-02 at 8 21 15 AM](https://user-images.githubusercontent.com/1235810/205237942-6fc2c890-3d0c-43f7-b6b4-c8a583b4637e.png)
…
![Screenshot 2022-12-02 at 8 21 34 AM](https://user-images.githubusercontent.com/1235810/205237965-c8fcd8e8-66d5-41e5-b2e3-cf79ebd28464.png)

So the recurrent use to the same icon actually ends up downloading over and over the same resource, and delays visibly the rendering of the header which is in the viewport. So we slow down the experience for the end user in a noticeable way
(200ms on desktop, >600ms on mobile).

## Options considered

### Switch over to an external icon sprite

This turned out to be mostly inefficient for this use case. The icon sprite ends up containing all icons for the website hoping to minimize the number of resources to load by combining them in a single file and then leveraging the `<use href="sprite.svg#<iconName>">` tag in SVG.

But it turns out that most pages only use a small subset of the icons and we actually end up using <10% of the sprite on each page. Additionally, we either end up loading several versions of the sprite because of async calls (header + footer reference it and end up loading it twice in parallel), or we have to significantly defer the async JS until after the initial sprite is loaded, which is also bad for the user experience and goes against the optimization we are trying to do in the first place (i.e. remove the loading delay on the header).

### Auto-generate an inline SVG sprite

The idea here is to create an inline SVG sprite in the page's `<body>` and populate it on every first encounter of an icon.
So we fetch the icon once, add it to the sprite, and then all subsequent references are swapped over for a ``<use href="sprite.svg#<iconName>">`.

## The result

![Screenshot 2022-12-02 at 8 49 23 AM](https://user-images.githubusercontent.com/1235810/205243067-145c85fc-c50a-41bb-837d-abe594b7bd25.png)

<img width="2560" alt="Screenshot 2022-12-02 at 9 20 03 AM" src="https://user-images.githubusercontent.com/1235810/205248147-c6151f1f-4918-4d05-8552-a69f9cc2940d.png">

So we visibly reduce the TBT and TTI.

We also reduced the amount and size of assets that are downloaded for the page
<img width="164" alt="Screenshot 2022-12-02 at 4 09 20 PM" src="https://user-images.githubusercontent.com/1235810/205324095-40aa5708-406c-49e7-89a2-a6c2ca42c4b1.png"> <img width="173" alt="Screenshot 2022-12-02 at 4 10 00 PM" src="https://user-images.githubusercontent.com/1235810/205324120-74749826-efa9-427a-951b-118b04343650.png">

And the size of the DOM itself as well:
<img width="302" alt="Screenshot 2022-12-02 at 5 09 48 PM" src="https://user-images.githubusercontent.com/1235810/205335819-37ccd602-0574-4dcf-bf8c-d1061f2e7f32.png"> <img width="303" alt="Screenshot 2022-12-02 at 5 09 55 PM" src="https://user-images.githubusercontent.com/1235810/205335837-8a4148ef-9c97-4755-9baf-b5d1e5b559ea.png">

It would also seem that on quite larger screens we also end up reducing the LCP, but harder to validate against the PSI service.

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.live/integrations/benefitadmincomparisonmatrix
- After: https://poc-svg-cache--bamboohr-website--ramboz.hlx.live/integrations/benefitadmincomparisonmatrix
