### PR TITLE
ZZ-1007

### DIFF
--- a/blocks/center-page-cta/center-page-cta.css
+++ b/blocks/center-page-cta/center-page-cta.css
@@ -22,7 +22,7 @@
 
 /* override since no "laptop" size */
 @media (min-width: 1800px) {
-    .has-bg > span.bg > svg:not(:only-child).laptop {
+    .has-bg > span.bg-block-center-page-cta > svg:not(:only-child).laptop {
         display: revert;
     }
 }

--- a/blocks/multi-element/multi-element.css
+++ b/blocks/multi-element/multi-element.css
@@ -502,6 +502,10 @@ main .multi-element p {
     margin-bottom: 24px;
 }
 
+.bg-top-multi-2-light .multi-element.industry h1 {
+    color: var(--theme-shade10);
+}
+
 .multi-element.content-color-tint-5 .content p {
     color: var(--theme-tint5);
 }


### PR DESCRIPTION
Limit center page cta display override to just cta (otherwise it messes with other backgrounds) Multi-element theme color should use dark text if background is light.

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/drafts/sclayton/topic-test
- After: https://sclayton-zz1007-template--bamboohr-website--bamboohr.hlx.page/drafts/sclayton/topic-test
