### PR TITLE
Ddanielson/style help

### DIFF
--- a/blocks/related-posts/related-posts.css
+++ b/blocks/related-posts/related-posts.css
@@ -13,6 +13,13 @@ main .section > .related-posts-wrapper {
   margin-top: 100px;
 }
 
+main .section > .related-posts-wrapper.no-background {
+  background-color: unset;
+  background-image: none;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 main .section > .related-posts-wrapper::before {
   content: 'You might also like...';
   display: block;

--- a/blocks/related-posts/related-posts.css
+++ b/blocks/related-posts/related-posts.css
@@ -135,3 +135,4 @@ main .related-posts-card-body a:any-link::after {
     padding: 150px 0;
   }
 }
+

--- a/blocks/related-posts/related-posts.css
+++ b/blocks/related-posts/related-posts.css
@@ -135,4 +135,3 @@ main .related-posts-card-body a:any-link::after {
     padding: 150px 0;
   }
 }
-

--- a/blocks/related-posts/related-posts.js
+++ b/blocks/related-posts/related-posts.js
@@ -19,6 +19,7 @@ export default async function decorate(block) {
     block.append(createBlogCard(article, 'related-posts'));
   });
 
+  // Adds .no-background class to related posts block
   const relatedPostsWrapper = document.querySelectorAll('.related-posts-wrapper');
   relatedPostsWrapper.forEach((relatedPost) => {
     if (relatedPost.querySelector('.no-background')) {

--- a/blocks/related-posts/related-posts.js
+++ b/blocks/related-posts/related-posts.js
@@ -18,4 +18,11 @@ export default async function decorate(block) {
   articles.forEach((article) => {
     block.append(createBlogCard(article, 'related-posts'));
   });
+
+  const relatedPostsWrapper = document.querySelectorAll('.related-posts-wrapper');
+  relatedPostsWrapper.forEach((relatedPost) => {
+    if (relatedPost.querySelector('.no-background')) {
+      relatedPost.classList.add('no-background');
+    }
+  });
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1318,11 +1318,11 @@ table td {
 }
 
 table thead {
-  background-color: var(--color-1);
+  background-color: var(--theme-tint5);
 }
 
 table thead th {
-  border-color: var(--color-1);
+  border-color: var(--theme-tint5);
 }
 
 table tbody th {


### PR DESCRIPTION
Made it so the `<th>` tag on a table inherits its background color from the page theme.
Added the option to remove the background on the related posts block.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/drafts/stickyeyes/onboarding
- After: https://ddanielson-style-help--bamboohr-website--bamboohr.hlx.page/drafts/stickyeyes/onboarding
