### PR TITLE
Update helix-query.yaml

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -284,8 +284,8 @@ indices:
           select: head > meta[name="category"]
           value: |
             attribute(el, 'content')
-        date:
-          select: head > meta[name="date"]
+        eventDate:
+          select: head > meta[name="event-date"]
           value: |
             attribute(el, 'content')
         robots:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -262,3 +262,37 @@ indices:
         select: none
         value: |
           parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+
+    webinars:
+      include:
+        - '/webinars/**'
+      target: /webinars/query-index
+      properties:
+        title:
+          select: head > meta[property="og:title"]
+          value: |
+            attribute(el, 'content')
+        description:
+          select: head > meta[property="og:description"]
+          value: |
+            attribute(el, 'content')
+        image:
+          select: head > meta[property="og:image"]
+          value: |
+            match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+        category:
+          select: head > meta[name="category"]
+          value: |
+            attribute(el, 'content')
+        date:
+          select: head > meta[name="date"]
+          value: |
+            attribute(el, 'content')
+        robots:
+          select: head > meta[name="robots"]
+          value: |
+            attribute(el, 'content')
+        lastModified:
+          select: none
+          value: |
+            parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')


### PR DESCRIPTION
Adds webinar info to helix-query.yaml

Fix #zz920

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/webinars/
- After: https://groberts-zz920--bamboohr-website--bamboohr.hlx.page/webinars/
