### PR TITLE
Update helix-query.yaml

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -168,6 +168,10 @@ indices:
         select: head > meta[name="form-submit-text"]
         value: |
           attribute(el, 'content')
+      hideFromLibrary:
+        select: head > meta[name="hide-from-library"]
+        value: |
+          attribute(el, 'content')
       robots:
         select: head > meta[name="robots"]
         value: |


### PR DESCRIPTION
Adds hide from library to resources query index yaml file

Fix #zz-1651

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/resources/
- After: https://groberts-zz1651--bamboohr-website--bamboohr.hlx.page/resources/
