### PR TITLE
Remove Convert script tag load from code

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -166,8 +166,6 @@ loadScript('header', adobeTagsSrc, async () => {
 
 loadScript('header', 'https://www.googleoptimize.com/optimize.js?id=OPT-PXL7MPD', null);
 
-loadScript('header', 'https://cdn-4.convertexperiments.com/js/10004673-10005501.js', null);
-
 loadTrustArcFormScript();
 
 /* google tag manager */


### PR DESCRIPTION
Remove Convert tag from code.  Will be added with GTM.

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/
- After: https://jwadsworth-remove-convert-tag--bamboohr-website--bamboohr.hlx.page/
