### PR TITLE
Removes customer homepage template

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -214,8 +214,7 @@ function loadTemplateCSS() {
       'paid-landing-page',
       'product-updates',
       'live-demo-webinar-lp',
-      'hr-101-guide',
-      'customer-homepage'
+      'hr-101-guide'
     ];
     if (templates.includes(template)) {
       const cssBase = `${window.hlx.serverPath}${window.hlx.codeBasePath}`;

--- a/styles/templates/customer-homepage.css
+++ b/styles/templates/customer-homepage.css
@@ -1,6 +1,0 @@
-.customer-homepage h1 {
-    color: var(--theme-shade5);
-    font-size: 70px;
-    line-height: 80px;
-    font-weight: 800;
-}


### PR DESCRIPTION
We no longer need this custom title style.

Fix #1851

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/drafts/groberts/homepage-customer
- After: https://groberts-remove-customer-home-styles--bamboohr-website--bamboohr.hlx.page/drafts/groberts/homepage-customer
