### PR TITLE
Update helix-query.yaml

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -428,11 +428,11 @@ indices:
       - '/customers/**'
     target: /customers/query-index
     properties:
-      customerName:
-        select: head > meta[name="customer-name"]
+      presenter:
+        select: head > meta[name="presenter"]
         value: |
           attribute(el, 'content')
-      jobTitle:
+      title:
         select: head > meta[name="job-title"]
         value: |
           attribute(el, 'content')
@@ -450,6 +450,10 @@ indices:
           attribute(el, 'content')
       hideFromLibrary:
         select: head > meta[name="hide-from-library"]
+        value: |
+          attribute(el, 'content')
+      publicationDate:
+        select: head > meta[name="publication-date"]
         value: |
           attribute(el, 'content')
       lastModified:


### PR DESCRIPTION
Fixes customer yaml to map to listing taxonomy.

Fix #1798

Test URLs:
- Before: https://main--bamboohr-website--bamboohr.hlx.page/customers/
- After: https://groberts-customer-yaml--bamboohr-website--bamboohr.hlx.page/customers/
