### PR TITLE
dynamic container size based on classes + viewport width

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -51,14 +51,14 @@ function readCookie(name) {
 function getBhrFeaturesCookie() {
   const value = readCookie('bhr_features');
   try {
-  	const decryptedValue = atob(value);
+    const decryptedValue = atob(value);
     return JSON.parse(decryptedValue);
-  } catch (err1) {	  
-	  try{
-		  return JSON.parse(value);
-	  } catch (err2) {
-		  return {};
-	  }
+  } catch (err1) {
+    try {
+      return JSON.parse(value);
+    } catch (err2) {
+      return {};
+    }
   }
 }
 
@@ -335,9 +335,10 @@ export function decorateBlock(block) {
 
   const blockWrapper = block.parentElement;
   blockWrapper.classList.add(`${shortBlockName}-wrapper`);
+  const regex = /\b(?:tablet-|laptop-|desktop)?(?:content-)?width-(?:xs|sm|md|lg|xl|2xl|full)\b/g;
 
   [...block.classList]
-    .filter((filter) => filter.match(/^content-width-/g))
+    .filter((filter) => filter.match(regex))
     .forEach((style) => {
       block.parentElement.classList.add(style);
       block.classList.remove(style);

--- a/styles/style-vars.css
+++ b/styles/style-vars.css
@@ -84,6 +84,14 @@
   --heading-color: var(--color-gray-12);
   --heading-font-family: 'Fira Sans', 'Fira Sans-fallback';
 
+  /* wrappers/containers sizes */
+  --width-xs: 560px;
+  --width-sm: 760px;
+  --width-md: 960px;
+  --width-lg: 1160px;
+  --width-xl: 1360px;
+  --width-2xl: 1560px;
+
   /* stylized font */
   --stylized-font-family: 'Permanent Marker', 'Permanent Marker-fallback';
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -849,32 +849,26 @@ main .section > div.width-2xl{
 @media(min-width: 600px) {
   /* tablet sizes and up */
   /* changing padding to non-mobile */
-  main .section > div.width-xs,
   main .section > div.tablet-width-xs {
     max-width: var(--width-xs) 
   } 
 
-  main .section > div.width-sm,
   main .section > div.tablet-width-sm {
     max-width:var(--width-sm) 
   }
   
-  main .section > div.width-md,
   main .section > div.tablet-width-md {
     max-width:var(--width-md) 
   }
   
-  main .section > div.width-lg,
   main .section > div.tablet-width-lg{
     max-width:var(--width-lg) 
   }
   
-  main .section > div.width-xl,
   main .section > div.tablet-width-xl{
     max-width:var(--width-xl) 
   }
   
-  main .section > div.width-2xl,
   main .section > div.tablet-width-2xl{
     max-width:var(--width-2xl) 
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -39,31 +39,31 @@ img {
 }
 
 @font-face {
-  font-family: "Permanent Marker-fallback";
+  font-family: 'Permanent Marker-fallback';
   size-adjust: 112.44%;
   ascent-override: 107%;
-  src: local("Arial");
+  src: local('Arial');
 }
 
 @font-face {
-  font-family: "Fira Sans-fallback";
+  font-family: 'Fira Sans-fallback';
   size-adjust: 95%;
   ascent-override: 90%;
-  src: local("Arial");
+  src: local('Arial');
 }
 
 @font-face {
-  font-family: "Red Hat Text-fallback";
+  font-family: 'Red Hat Text-fallback';
   size-adjust: 99.56%;
   ascent-override: 110%;
-  src: local("Arial");
+  src: local('Arial');
 }
 
 @font-face {
-  font-family: "Red Hat Display-fallback";
-  size-adjust: 98.50%;
+  font-family: 'Red Hat Display-fallback';
+  size-adjust: 98.5%;
   ascent-override: 110%;
-  src: local("Arial");
+  src: local('Arial');
 }
 
 body {
@@ -122,7 +122,7 @@ a.button:focus {
   color: var(--color-white);
   background-color: var(--theme-shade5);
   border: solid 2px transparent;
-  transition: background-color .25s ease-in-out;
+  transition: background-color 0.25s ease-in-out;
 }
 
 .button-theme-shade-5 a.button.light:not(.link):any-link {
@@ -814,7 +814,7 @@ main .section > div {
   margin-right: auto;
 }
 
-main .section >  div.width-full {
+main .section > div.width-full {
   max-width: 100%;
   padding-left: 0;
   padding-right: 0;
@@ -825,111 +825,110 @@ main .section >  div.width-full {
 /* mobile and up */
 
 main .section > div.width-xs {
-  max-width: var(--width-xs) 
+  max-width: var(--width-xs);
 }
 
 main .section > div.width-sm {
-  max-width:var(--width-sm) 
+  max-width: var(--width-sm);
 }
 
 main .section > div.width-md {
-  max-width:var(--width-md) 
+  max-width: var(--width-md);
 }
 
-main .section > div.width-lg{
-  max-width:var(--width-lg) 
+main .section > div.width-lg {
+  max-width: var(--width-lg);
 }
 
-main .section > div.width-xl{
-  max-width:var(--width-xl) 
+main .section > div.width-xl {
+  max-width: var(--width-xl);
 }
 
-main .section > div.width-2xl{
-  max-width:var(--width-2xl) 
+main .section > div.width-2xl {
+  max-width: var(--width-2xl);
 }
 
-@media(min-width: 600px) {
+@media (min-width: 600px) {
   /* tablet sizes and up */
 
   main .section > div.tablet-width-xs {
-    max-width: var(--width-xs) 
-  } 
+    max-width: var(--width-xs);
+  }
 
   main .section > div.tablet-width-sm {
-    max-width:var(--width-sm) 
+    max-width: var(--width-sm);
   }
-  
+
   main .section > div.tablet-width-md {
-    max-width:var(--width-md) 
+    max-width: var(--width-md);
   }
-  
-  main .section > div.tablet-width-lg{
-    max-width:var(--width-lg) 
+
+  main .section > div.tablet-width-lg {
+    max-width: var(--width-lg);
   }
-  
-  main .section > div.tablet-width-xl{
-    max-width:var(--width-xl) 
+
+  main .section > div.tablet-width-xl {
+    max-width: var(--width-xl);
   }
-  
-  main .section > div.tablet-width-2xl{
-    max-width:var(--width-2xl) 
+
+  main .section > div.tablet-width-2xl {
+    max-width: var(--width-2xl);
   }
 }
 
-@media(min-width: 900px) {
+@media (min-width: 900px) {
   /* laptop sizes and up */
   main .section > div.laptop-width-xs {
-    max-width: var(--width-xs) 
-  } 
+    max-width: var(--width-xs);
+  }
 
   main .section > div.laptop-width-sm {
-    max-width:var(--width-sm) 
+    max-width: var(--width-sm);
   }
-  
+
   main .section > div.laptop-width-md {
-    max-width:var(--width-md) 
+    max-width: var(--width-md);
   }
-  
-  main .section > div.laptop-width-lg{
-    max-width:var(--width-lg) 
+
+  main .section > div.laptop-width-lg {
+    max-width: var(--width-lg);
   }
-  
-  main .section > div.laptop-width-xl{
-    max-width:var(--width-xl) 
+
+  main .section > div.laptop-width-xl {
+    max-width: var(--width-xl);
   }
-  
-  main .section > div.laptop-width-2xl{
-    max-width:var(--width-2xl) 
+
+  main .section > div.laptop-width-2xl {
+    max-width: var(--width-2xl);
   }
 }
 
-@media(min-width: 1200px) {
+@media (min-width: 1200px) {
   /* desktop sizes and up */
   main .section > div.desktop-width-xs {
-    max-width: var(--width-xs) 
-  } 
+    max-width: var(--width-xs);
+  }
 
   main .section > div.desktop-width-sm {
-    max-width:var(--width-sm) 
+    max-width: var(--width-sm);
   }
-  
+
   main .section > div.desktop-width-md {
-    max-width:var(--width-md) 
+    max-width: var(--width-md);
   }
-  
-  main .section > div.desktop-width-lg{
-    max-width:var(--width-lg) 
+
+  main .section > div.desktop-width-lg {
+    max-width: var(--width-lg);
   }
-  
-  main .section > div.desktop-width-xl{
-    max-width:var(--width-xl) 
+
+  main .section > div.desktop-width-xl {
+    max-width: var(--width-xl);
   }
-  
-  main .section > div.desktop-width-2xl{
-    max-width:var(--width-2xl) 
+
+  main .section > div.desktop-width-2xl {
+    max-width: var(--width-2xl);
   }
 }
-
 
 main .section > div:empty {
   padding: 0;
@@ -1712,7 +1711,7 @@ body.modal-open {
 @media screen and (min-width: 900px) {
   .modal {
     padding: 50px 40px;
-		width: 80%;
+    width: 80%;
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -821,7 +821,9 @@ main .section >  div.width-full {
 }
 
 /* TEST: responsive block wrapper/containers */
+
 /* mobile and up */
+
 main .section > div.width-xs {
   max-width: var(--width-xs) 
 }
@@ -848,7 +850,7 @@ main .section > div.width-2xl{
 
 @media(min-width: 600px) {
   /* tablet sizes and up */
-  /* changing padding to non-mobile */
+
   main .section > div.tablet-width-xs {
     max-width: var(--width-xs) 
   } 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -814,6 +814,127 @@ main .section > div {
   margin-right: auto;
 }
 
+main .section >  div.width-full {
+  max-width: 100%;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+/* TEST: responsive block wrapper/containers */
+/* mobile and up */
+main .section > div.width-xs {
+  max-width: var(--width-xs) 
+}
+
+main .section > div.width-sm {
+  max-width:var(--width-sm) 
+}
+
+main .section > div.width-md {
+  max-width:var(--width-md) 
+}
+
+main .section > div.width-lg{
+  max-width:var(--width-lg) 
+}
+
+main .section > div.width-xl{
+  max-width:var(--width-xl) 
+}
+
+main .section > div.width-2xl{
+  max-width:var(--width-2xl) 
+}
+
+@media(min-width: 600px) {
+  /* tablet sizes and up */
+  /* changing padding to non-mobile */
+  main .section > div.width-xs,
+  main .section > div.tablet-width-xs {
+    max-width: var(--width-xs) 
+  } 
+
+  main .section > div.width-sm,
+  main .section > div.tablet-width-sm {
+    max-width:var(--width-sm) 
+  }
+  
+  main .section > div.width-md,
+  main .section > div.tablet-width-md {
+    max-width:var(--width-md) 
+  }
+  
+  main .section > div.width-lg,
+  main .section > div.tablet-width-lg{
+    max-width:var(--width-lg) 
+  }
+  
+  main .section > div.width-xl,
+  main .section > div.tablet-width-xl{
+    max-width:var(--width-xl) 
+  }
+  
+  main .section > div.width-2xl,
+  main .section > div.tablet-width-2xl{
+    max-width:var(--width-2xl) 
+  }
+}
+
+@media(min-width: 900px) {
+  /* laptop sizes and up */
+  main .section > div.laptop-width-xs {
+    max-width: var(--width-xs) 
+  } 
+
+  main .section > div.laptop-width-sm {
+    max-width:var(--width-sm) 
+  }
+  
+  main .section > div.laptop-width-md {
+    max-width:var(--width-md) 
+  }
+  
+  main .section > div.laptop-width-lg{
+    max-width:var(--width-lg) 
+  }
+  
+  main .section > div.laptop-width-xl{
+    max-width:var(--width-xl) 
+  }
+  
+  main .section > div.laptop-width-2xl{
+    max-width:var(--width-2xl) 
+  }
+}
+
+@media(min-width: 1200px) {
+  /* desktop sizes and up */
+  main .section > div.desktop-width-xs {
+    max-width: var(--width-xs) 
+  } 
+
+  main .section > div.desktop-width-sm {
+    max-width:var(--width-sm) 
+  }
+  
+  main .section > div.desktop-width-md {
+    max-width:var(--width-md) 
+  }
+  
+  main .section > div.desktop-width-lg{
+    max-width:var(--width-lg) 
+  }
+  
+  main .section > div.desktop-width-xl{
+    max-width:var(--width-xl) 
+  }
+  
+  main .section > div.desktop-width-2xl{
+    max-width:var(--width-2xl) 
+  }
+}
+
+
 main .section > div:empty {
   padding: 0;
 }


### PR DESCRIPTION
Here it is a draft of a way to handle max widths arounds our blocks at different screen sizes.

This would allow us to be explicit about the max-width we want at different screen sizes.
I am open to feedback, changes, or even throwing it away if you think it is not helpful haha.

eg
`Columns(width-lg, desktop-sm)`
This would keep the containers max-width to lg (1160px) until it reaches desktop size. At desktop changes the max-width of the block to sm(760px).

This is how to use them and how they look.
https://docs.google.com/document/d/1CZc3XrsOE5J_X3sq1fTVcGji5YrTnNUdUoJxgHTqijo/edit
https://doliva-zz-1715-b--bamboohr-website--bamboohr.hlx.page/blocks/templates/content-guide-template